### PR TITLE
Use performance.now where available

### DIFF
--- a/addon/core/transition-data.js
+++ b/addon/core/transition-data.js
@@ -1,14 +1,16 @@
+import performanceNow from '../utils/performance-now';
+
 function TransitionData(args) {
   this.destURL = args.destURL;
   this.destRoute = args.destRoute;
-  this.startTime = new Date().valueOf();
+  this.startTime = performanceNow();
   this.endTime = null;
   this.routes = [];
   this.viewData = [];
 }
 
 function t() {
-  return new Date().valueOf();
+  return performanceNow();
 }
 
 TransitionData.prototype = {

--- a/addon/utils/performance-now.js
+++ b/addon/utils/performance-now.js
@@ -1,0 +1,7 @@
+export default function performanceNow() {
+  if ('performance' in window) {
+    return window.performance.now();
+  } else {
+    return new Date().valueOf();
+  }
+}

--- a/app/utils/performance.js
+++ b/app/utils/performance.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-perf/utils/performance-now';

--- a/tests/acceptance/event-body-test.js
+++ b/tests/acceptance/event-body-test.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import { module, test } from 'qunit';
 import startApp from '../../tests/helpers/start-app';
 import validateEvent from '../../tests/helpers/validate-event';
+import performanceNow from 'ember-perf/utils/performance-now';
 
 let application;
 
@@ -19,7 +20,7 @@ module('Acceptance | event data structure', {
 
 test('Initial load, then drilling in', function(assert) {
   let datas = [];
-  let testStartTime = new Date().valueOf();
+  let testStartTime = performanceNow();
 
   application.perfService.on('transitionComplete', data => {
     datas.push(data);
@@ -41,7 +42,7 @@ test('Initial load, then drilling in', function(assert) {
 
 test('Initial load, then drilling in, then back out', function(assert) {
   let datas = [];
-  let testStartTime = new Date().valueOf();
+  let testStartTime = performanceNow();
 
   application.perfService.on('transitionComplete', data => {
     datas.push(data);
@@ -77,7 +78,7 @@ test('Initial load, then drilling in, then back out', function(assert) {
 
 test('Initial load, then drilling in, then pivoting', function(assert) {
   let datas = [];
-  let testStartTime = new Date().valueOf();
+  let testStartTime = performanceNow();
 
   application.perfService.on('transitionComplete', data => {
     datas.push(data);


### PR DESCRIPTION
This commit updates transition-data to use the high resolution timestamp
provided by `performance.now` where available, and falls back to `new
Date().valueOf()` for unsupported browsers.