### PR TITLE
Prevent viewData mutation after transitionComplete event.

### DIFF
--- a/addon/core/transition-data.js
+++ b/addon/core/transition-data.js
@@ -4,6 +4,7 @@ function TransitionData(args) {
   this.destURL = args.destURL;
   this.destRoute = args.destRoute;
   this.startTime = performanceNow();
+  this._active = true;
   this.endTime = null;
   this.routes = [];
   this.viewData = [];
@@ -18,6 +19,7 @@ TransitionData.prototype = {
   finish() {
     this.endTime = t();
     this.elapsedTime = this.endTime - this.startTime;
+    this._active = false;
   },
 
   activateRoute(route) {
@@ -42,6 +44,10 @@ TransitionData.prototype = {
   },
 
   willRender(name, timestamp, payload) {
+    if (!this._active) {
+      return;
+    }
+
     switch (name) {
       case 'render.component':
       case 'render.view':
@@ -64,6 +70,10 @@ TransitionData.prototype = {
   },
 
   didRender(name, timestamp, payload) {
+    if (!this._active) {
+      return;
+    }
+
     switch (name) {
       case 'render.component':
       case 'render.view':

--- a/tests/acceptance/customization-test.js
+++ b/tests/acceptance/customization-test.js
@@ -59,3 +59,28 @@ test('Initial load, then pivoting on a parent', function(assert) {
   });
 
 });
+
+test('Initial load, then toggling additional views', function(assert) {
+  let transitionData;
+  let dataCount = 0;
+  let viewsCountWhenEventFired = 0;
+  application.perfService.on('transitionComplete', (data) => {
+    dataCount++;
+    transitionData = data;
+    viewsCountWhenEventFired = data.viewData.length;
+  });
+
+  visit('/company/1/building/2');
+
+  andThen(function() {
+    assert.equal(dataCount, 1, 'Only one event has been fired for the initial load');
+    assert.equal(currentURL(), '/company/1/building/2');
+  });
+
+  click('.btn-edit');
+
+  andThen(function() {
+    assert.equal(dataCount, 1, 'only a single transitionComplete event was fired');
+    assert.equal(transitionData.viewData.length, viewsCountWhenEventFired, 'transitionData should not be mutated');
+  });
+});

--- a/tests/dummy/app/controllers/company/building.js
+++ b/tests/dummy/app/controllers/company/building.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  editing: false,
+
+  actions: {
+    edit() {
+      this.set('editing', true);
+    }
+  }
+});

--- a/tests/dummy/app/routes/company/building.js
+++ b/tests/dummy/app/routes/company/building.js
@@ -14,5 +14,11 @@ export default Ember.Route.extend({
       });
     }
     // jscs: enable
+  },
+
+  setupController(controller) {
+    this._super(...arguments);
+
+    controller.set('editing', false);
   }
 });

--- a/tests/dummy/app/templates/company/building.hbs
+++ b/tests/dummy/app/templates/company/building.hbs
@@ -4,3 +4,9 @@
 {{else}}
 <h1>Building not found</h1>
 {{/if}}
+
+{{#if editing}}
+    {{input value=content.name}}
+{{else}}
+  <button {{action 'edit'}} class="btn-edit">Show more</button>
+{{/if}}


### PR DESCRIPTION
Prior to this change the `TransitionData` object was created when the Router initiates a `_doURLTransition` or `_doTransition`, then any rendered views are attached to the previously created `TransitionData` object.  This is a wonderful way to see a breakdown of views as they relate to a given router transition!

Unfortunately, `this.transitionData` is never reset in the `service:ember-perf`. This means that any views/components that are created while still on the route are mutating `this.transitionData.viewData` well after the `transitionComplete` event is triggered.

This commit ensures `viewData` is not changed after `TransitionData#finish` is called.