### PR TITLE
Making blueprints pass JSHINT 

### DIFF
--- a/blueprints/ember-perf-initializer/files/app/initializers/__name__.js
+++ b/blueprints/ember-perf-initializer/files/app/initializers/__name__.js
@@ -1,4 +1,5 @@
 import instanceInitializer from '../instance-initializers/<%= dasherizedModuleName %>';
+import Ember from 'ember';
 
 var EMBER_VERSION_REGEX = /^([0-9]+)\.([0-9]+)\.([0-9]+)(?:(?:\-(alpha|beta)\.([0-9]+)(?:\.([0-9]+))?)?)?(?:\+(canary))?(?:\.([0-9abcdef]+))?(?:\-([A-Za-z0-9\.\-]+))?(?:\+([A-Za-z0-9\.\-]+))?$/;
 
@@ -23,7 +24,7 @@ export function initialize() {
   const registry = !!arguments[1] ? arguments[0] : application.registry;
 
   var isPre111 = parseInt(VERSION_INFO[1], 10) < 2 && parseInt(VERSION_INFO[2], 10) < 12;
-  const container = application.__container__;
+
   if (isPre111) {
     // For versions before 1.12.0, we have to call the instanceInitializer
     instanceInitializer.initialize(registry, application);

--- a/blueprints/ember-perf-initializer/files/app/instance-initializers/__name__.js
+++ b/blueprints/ember-perf-initializer/files/app/instance-initializers/__name__.js
@@ -1,3 +1,7 @@
+import Ember from 'ember';
+
+const { log } = Ember.Logger;
+
 export function initialize() {
     // Handle 1.12.x case, where signature is
     //  initialize(instance) {...}
@@ -5,10 +9,14 @@ export function initialize() {
     const container = !!arguments[1] ? arguments[0] : instance.container;
 
     let perfService = container.lookup('service:ember-perf');
+
     perfService.on('transitionComplete', transitionData => {
+      log('transitionComplete', transitionData);
       // DO SOMETHING WITH TRANSITION DATA
     });
+
     perfService.on('renderComplete', transitionData => {
+      log('renderComplete', transitionData);
       // DO SOMETHING WITH RENDER DATA
     });
 


### PR DESCRIPTION
I had an issue adding `ember-perf` our app where jshint throw some warnings. 

`blueprints/ember-perf-initializer/files/app/initializers/__name__.js`
- The container is declared but never used
- Ember is used but never declared

`blueprints/ember-perf-initializer/files/app/instance-initializers/__name__.js`
transitionData is declared but never used. 

I added `Ember.Logger.log` here so a DEV could get instant feedback after installing the addon. 

The other approach would be to comment out these two methods and allow the Dev installing the addon uncomment the code when they are ready to use those methods.

Open to thoughts here. 

 