### PR TITLE
Make ember-getowner-polyfill a dep.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.5",
-    "ember-getowner-polyfill": "1.0.1",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "ember-suave": "^2.0.1",
@@ -50,7 +49,8 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6"
+    "ember-cli-babel": "^5.1.6",
+    "ember-getowner-polyfill": "^1.0.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
This is imported from in `addon/ext/router.js`, so it needs to be a dep.