### PR TITLE
handle empty route object in routeFinishedSetup

### DIFF
--- a/addon/core/transition-data.js
+++ b/addon/core/transition-data.js
@@ -40,8 +40,11 @@ prototype.activateRoute = function activateRoute(route) {
 prototype.routeFinishedSetup = function routeFinishedSetup(route) {
   let endTime = t();
   let [r] = this.routes.filter((r) => r.name === route.routeName);
-  r.endTime = endTime;
-  r.elapsedTime = r.endTime - r.startTime;
+
+  if (r) {
+    r.endTime = endTime;
+    r.elapsedTime = r.endTime - r.startTime;
+  }
 };
 
 prototype._viewAdded = function _viewAdded(view, index) {


### PR DESCRIPTION
Hi Mike, I hope everything is fine. 
Currently we are going to adopt ember-perf. But found a little issue:

Transition data's activateRoute function won't call when my routes have already use active() hook which causing route object is missing in transition-data. So I think Empty route object has better to be checked in routeFinishedSetup of transition-data.

Yubin