### PR TITLE
Ember-getowner-polyfill to version 1.1.1

### DIFF
--- a/addon/ext/router.js
+++ b/addon/ext/router.js
@@ -1,7 +1,6 @@
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
 
-const { computed, on, Mixin } = Ember;
+const { computed, on, Mixin, getOwner } = Ember;
 
 export default Mixin.create({
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "ember-load-initializers": "^0.6.0",
     "ember-resolver": "^2.0.3",
     "ember-suave": "^4.0.1",
-    "loader.js": "^4.0.10",
+    "loader.js": "^4.1.0",
     "rsvp": "^3.3.3"
   },
   "keywords": [
@@ -57,7 +57,8 @@
     "measure"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.7"
+    "ember-cli-babel": "^5.1.7",
+    "ember-getowner-polyfill": "1.1.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -57,8 +57,7 @@
     "measure"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.7",
-    "ember-getowner-polyfill": "^1.0.1"
+    "ember-cli-babel": "^5.1.7"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
Removed `import getOwner from 'ember-getowner-polyfill';` in-favor of `ember-getowner-polyfill` directly providing a polyfill for `Ember.getOwner`