### PR TITLE
send all transition context params, not just the first one

### DIFF
--- a/addon/services/ember-perf.js
+++ b/addon/services/ember-perf.js
@@ -65,13 +65,14 @@ export default Base.extend(Evented, {
     }
     transitionInfo.promise._emberPerfTransitionId = transitionCounter++;
     let transitionRoute = transitionInfo.promise.targetName || get(transitionInfo.promise, 'intent.name');
-    let transitionCtxt = get(transitionInfo.promise, 'intent.contexts') ? (get(transitionInfo.promise, 'intent.contexts') || [])[0] : null;
+    let transitionCtxt = get(transitionInfo.promise, 'intent.contexts');
+    let hasTransitionCtxt = transitionCtxt && transitionCtxt[0];
     let transitionUrl = get(transitionInfo.promise, 'intent.url');
     assert('Must have at least a route name', transitionRoute);
 
     if (!transitionUrl) {
-      if (transitionCtxt) {
-        transitionUrl = transitionInfo.promise.router.generate(transitionRoute, transitionCtxt);
+      if (hasTransitionCtxt) {
+        transitionUrl = transitionInfo.promise.router.generate(transitionRoute, ...transitionCtxt);
       } else {
         transitionUrl = transitionInfo.promise.router.generate(transitionRoute);
       }

--- a/tests/acceptance/companies-test.js
+++ b/tests/acceptance/companies-test.js
@@ -21,7 +21,7 @@ test('Basic demo page test', function(assert) {
 
   andThen(function() {
     assert.equal(currentURL(), '/companies');
-    assert.equal(find('.companies-list li').length, 3, 'One company in list');
+    assert.equal(find('.companies-list li.company').length, 3, 'One company in list');
     assert.equal(find('.companies-list .company:first-child').text().trim(), 'Yahoo', 'Yahoo is first company');
   });
 

--- a/tests/acceptance/event-body-test.js
+++ b/tests/acceptance/event-body-test.js
@@ -54,6 +54,7 @@ test('More than one route context object', function(assert) {
   andThen(function() {
     assert.ok(datas, 'Data is present');
     assert.equal(datas.length, 1, 'Only one event fired');
+    // don't validate event contents because validateEvent assumes a building route
   });
 
   click('a[href=\'/company/1/building/1\']');

--- a/tests/acceptance/event-body-test.js
+++ b/tests/acceptance/event-body-test.js
@@ -42,6 +42,29 @@ test('Initial load, then drilling in', function(assert) {
 
 });
 
+test('More than one route context object', function(assert) {
+  let datas = [];
+
+  application.perfService.on('transitionComplete', (data) => {
+    datas.push(data);
+  });
+
+  visit('/companies');
+
+  andThen(function() {
+    assert.ok(datas, 'Data is present');
+    assert.equal(datas.length, 1, 'Only one event fired');
+  });
+
+  click('a[href=\'/company/1/building/1\']');
+  andThen(function() {
+    assert.equal(datas.length, 2, 'Only two events fired');
+    let data = datas[datas.length - 1];
+    assert.equal(data.destURL, '/company/1/building/1', 'Intent URL is correct');
+    assert.equal(data.destRoute, 'company.building.index', 'Intent route is correct');
+  });
+});
+
 test('Initial load, then drilling in, then back out', function(assert) {
   let datas = [];
   let testStartTime = performanceNow();

--- a/tests/dummy/app/templates/companies.hbs
+++ b/tests/dummy/app/templates/companies.hbs
@@ -1,6 +1,13 @@
 <ul class='companies-list'>
   {{#each model as |company|}}
     {{items-list-item  class='company' content=company itemRoute='company'}}
+    <ul>
+    {{#each company.buildings as |building|}}
+        <li>
+            {{#link-to 'company.building' company building class="building"}}Building {{building}}{{/link-to}}
+        </li>
+    {{/each}}
+    </ul>
   {{/each}}
 </ul>
 

--- a/tests/dummy/app/templates/companies.hbs
+++ b/tests/dummy/app/templates/companies.hbs
@@ -1,13 +1,7 @@
 <ul class='companies-list'>
   {{#each model as |company|}}
     {{items-list-item  class='company' content=company itemRoute='company'}}
-    <ul>
-    {{#each company.buildings as |building|}}
-        <li>
-            {{#link-to 'company.building' company building class="building"}}Building {{building}}{{/link-to}}
-        </li>
-    {{/each}}
-    </ul>
+    ({{#link-to 'company.building' company 1 class="building"}}Building 1{{/link-to}})
   {{/each}}
 </ul>
 


### PR DESCRIPTION
leaving out params causes "Uncaught Error: You must provide param model_id to generate."
when generating URL from measureTransition

fix for https://github.com/mike-north/ember-perf/issues/101